### PR TITLE
Pin actions to full-length commit sha

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Update package lists
         run: |
@@ -17,7 +17,7 @@ jobs:
         run: |
           sudo apt-get install -y age
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version: "~1.24.6"
 
@@ -42,7 +42,7 @@ jobs:
           GOARCH: arm64
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: systemd-age-creds
           path: dist/

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
 
       - name: Enable auto-merge
         if: steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: DeterminateSystems/determinate-nix-action@9a921d81e9a16a9ad8423a63a7b31deb601139a6 # v3.14.0
 
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
 
       - name: Check flake
         run: |


### PR DESCRIPTION
## Summary
- pin Go workflow actions to specific commit SHAs
- pin Dependabot metadata action to a fixed commit
- pin the magic Nix cache action to a stable revision

## Testing
- Not run (CI only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b543dd0883268e10525cec6abf4a)